### PR TITLE
Update confluence.rb

### DIFF
--- a/lib/markdown2confluence/convertor/confluence.rb
+++ b/lib/markdown2confluence/convertor/confluence.rb
@@ -106,7 +106,7 @@ module Kramdown
       alias :convert_dl :convert_ul
 
       def convert_li(el, indent)
-        "#{'-'*(indent/2)}#{inner(el, 0)}"
+        "#{'*'*(indent/2)}#{inner(el, 0)}"
       end
 
       alias :convert_dd :convert_li


### PR DESCRIPTION
Nested lists must use the `*` character instead of the `-` character. Therefore, I switched out the replacement in the `convert_li` function.
