### PR TITLE
Remove unused "i" variable when marking ol children as ordered.

### DIFF
--- a/lib/markdown2confluence/convertor/confluence.rb
+++ b/lib/markdown2confluence/convertor/confluence.rb
@@ -69,7 +69,7 @@ module Kramdown
         @stack.push(el)
 
         if el.type == :ol
-          el.children.each {|c, i| c.options[:ordered] = true}
+          el.children.each {|c| c.options[:ordered] = true}
         end
 
         el.children.each do |inner_el|


### PR DESCRIPTION
This doesn't actually change the code at all.  `i` is defined as nil in the affected block and totally ignored.  This is just a small cleanup.